### PR TITLE
Changes to rng, not recreating a new generator every time.

### DIFF
--- a/src/include/ggml-util.h
+++ b/src/include/ggml-util.h
@@ -184,12 +184,13 @@ struct ggml_tensor* concat_3d(struct ggml_context* ctx, struct ggml_tensor* a, s
     return b_set;
 }
 
+extern std::default_random_engine rng;
+
 struct ggml_tensor* tensor_randn(struct ggml_context* ctx, struct ggml_allocr* allocr, std::vector<int64_t> dims) {
     auto tensor = ggml_new_tensor(ctx, DEFAULT_TENSOR_TYPE, dims.size(), dims.data());
     ALLOC(tensor)
     auto data = static_cast<float*>(tensor->data);
     auto size = ggml_nelements(tensor) ;
-    std::mt19937 rng;
     std::normal_distribution<float> dist(0.0f, 1.0f);
     for (int i = 0; i < size; ++i) {
         data[i] = dist(rng);

--- a/src/vits.cpp
+++ b/src/vits.cpp
@@ -28,6 +28,8 @@ vits_model::~vits_model() {
     ggml_free(weights_ctx);
 }
 
+std::default_random_engine rng;
+
 template<>
 std::vector<int> vits_model::load_vector_impl<int>(const std::string& serialized_data) {
     this->log("Loading vector %s\n", serialized_data.c_str());


### PR DESCRIPTION
In the function tensor_randn (ggml-util.h:189), you create a new random number generator every time. This is probably not something you want. Changes work well with other changes so you can seed the rng at startup with command line parameters.